### PR TITLE
feat: add jsx tsx and vue comments support

### DIFF
--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -17,3 +17,20 @@ let g:context#commentstring#table.html = {
 
 let g:context#commentstring#table.xhtml = g:context#commentstring#table.html
 
+let g:context#commentstring#table['javascript.jsx'] = {
+			\ 'jsxStatment' : '/*%s*/',
+			\ 'jsxRegion' : '{/*%s*/}',
+			\}
+
+let g:context#commentstring#table['typescript.tsx'] = {
+			\ 'tsxStatment' : '/*%s*/',
+			\ 'tsxRegion' : '{/*%s*/}',
+			\}
+
+let g:context#commentstring#table.vue = {
+			\ 'javaScript'  : '//%s',
+			\ 'cssStyle'    : '/*%s*/',
+			\}
+
+let g:context#commentstring#table['typescript.jsx'] = g:context#commentstring#table['typescript.tsx']
+


### PR DESCRIPTION
Add support for modern frontend web frameworks like React and Vue.js

JavaScript and Typescript support.
Credits for Vue part https://github.com/pearofducks/vim-context-commentstring