### PR TITLE
Reverse synstack before setting commentstring

### DIFF
--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -23,6 +23,7 @@ let g:context#commentstring#table['javascript.jsx'] = {
 			\ 'jsxStatment' : '// %s',
 			\ 'jsxRegion' : '{/*%s*/}',
 			\ 'jsxTag' : '{/*%s*/}',
+			\ 'jsFuncBlock' : '// %s',
 			\}
 
 let g:context#commentstring#table['typescript.jsx'] = {

--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -48,3 +48,9 @@ let g:context#commentstring#table.vue = {
 			\ 'cssStyle'    : '/*%s*/',
 			\}
 
+let g:context#commentstring#comments_table = {}
+let g:context#commentstring#comments_table.vue = {
+			\ 'htmlTag': 's:<!--,m:    ,e:-->',
+			\ 'vue_typescript': 's1:/*,mb:*,ex:*/,://',
+			\ 'cssStyle': 's1:/*,mb:*,ex:*/,://',
+			\ }

--- a/plugin/context-commentstring.vim
+++ b/plugin/context-commentstring.vim
@@ -22,8 +22,13 @@ function! s:Setup()
 			let b:original_commentstring=&l:commentstring
 			autocmd CursorMoved <buffer> call <SID>UpdateCommentString()
 		endif
+		if !empty(&filetype) && has_key(g:context#commentstring#comments_table, &filetype)
+			let b:original_comments=&l:comments
+			autocmd CursorMoved <buffer> call <SID>UpdateComments()
+		endif
 	augroup END
 endfunction
+
 
 
 function! s:UpdateCommentString()
@@ -38,6 +43,20 @@ function! s:UpdateCommentString()
 		endfor
 	endif
 	let &l:commentstring = b:original_commentstring
+endfunction
+
+function! s:UpdateComments()
+	let stack = synstack(line('.'), col('.'))
+	call reverse(stack)
+	if !empty(stack)
+		for name in map(stack, 'synIDattr(v:val, "name")')
+			if has_key(g:context#commentstring#comments_table[&filetype], name)
+				let &l:comments = g:context#commentstring#comments_table[&filetype][name]
+        return
+			endif
+		endfor
+	endif
+	let &l:commentstring = b:original_comments
 endfunction
 
 

--- a/plugin/context-commentstring.vim
+++ b/plugin/context-commentstring.vim
@@ -28,6 +28,7 @@ endfunction
 
 function! s:UpdateCommentString()
 	let stack = synstack(line('.'), col('.'))
+	call reverse(stack)
 	if !empty(stack)
 		for name in map(stack, 'synIDattr(v:val, "name")')
 			if has_key(g:context#commentstring#table[&filetype], name)


### PR DESCRIPTION
I had a problem that the commentstring does not get set correctly in the following case in a JSX file (cursor noted by `|`):

```jsx
const MyComponent = () => {
    return {
        <button
            onClick={() => {
                |console.log('hello')
                 ^ Cursor is here
            }}
        >
            Hello!
        </button>
    }
}
```

The commentstring at that location should be `// %s` but it's not really possible to match the syntax group correctly. Here's how the synstack looks like at that location:

```
['jsFuncBlock', 'jsParen', 'jsxRegion', 'jsxTag', 'jsxEscapeJsAttributes', 'jsFuncBlock', 'jsGlobalObjects']
```

When looping through this list from left to right, the `jsxRegion` syntax group gets matched first and the commentstring will be `{/*%s*/}`. If the synstack is reversed, however, the first match will
be `jsFuncBlock` and the commentstring will be set to `// %s` as expected.

---

Do you think that this is a good solution for the problem? Maybe there's a better approach to get by example to work?

---

**Note:** I didn't test to see if the other file types work since I don't use those that much myself (`vim`, `html`, `xhtml`, `typescript.jsx`, `typescript.tsx`, `vue`).