### PR TITLE
Adds support for svelte

### DIFF
--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -47,3 +47,10 @@ let g:context#commentstring#table.vue = {
 			\ 'cssStyle'    : '/*%s*/',
 			\}
 
+let g:context#commentstring#table.svelte = {
+      \ 'javaScript': '//%s',
+      \ 'cssStyle': '/*%s*/',
+      \ 'htmlTag': '<!-- %s -->',
+      \ 'htmlEndTag': '<!-- %s -->',
+      \ 'undefined': '<!-- %s -->'
+      \}

--- a/plugin/context-commentstring.vim
+++ b/plugin/context-commentstring.vim
@@ -35,6 +35,9 @@ function! s:UpdateCommentString()
 				return
 			endif
 		endfor
+  elseif exists("g:context#commentstring#table[&filetype]['undefined']")
+	  let &l:commentstring = g:context#commentstring#table[&filetype]['undefined']
+		return
 	endif
 	let &l:commentstring = b:original_commentstring
 endfunction


### PR DESCRIPTION
I don't know if you would be open to this, but it allows commenting in `svelte`.

I believe this (albeit a bit of hack) solves the issue you described in the docs:

> At the moment, there is only one known issue: it doesn't work properly at the
edges of the embedded language, where the boundary is. Is unlikely that this
will have a solution, and is an uncommon case anyway. Try to move the cursor
one extra line further.

One must simply define an `undefined` key in the filetype library with a value for how that case should be handled. 