### PR TITLE
Dynamically set comments setting

### DIFF
--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -47,3 +47,9 @@ let g:context#commentstring#table.vue = {
 			\ 'cssStyle'    : '/*%s*/',
 			\}
 
+let g:context#commentstring#comments_table = {}
+let g:context#commentstring#comments_table.vue = {
+			\ 'htmlTag': 's:<!--,m:    ,e:-->',
+			\ 'vue_typescript': 's1:/*,mb:*,ex:*/,://',
+			\ 'cssStyle': 's1:/*,mb:*,ex:*/,://',
+			\ }

--- a/doc/context-commentstring.txt
+++ b/doc/context-commentstring.txt
@@ -55,6 +55,11 @@ Pope's |commentary.txt| plugin, a utility to comment and uncomment lines of
 code. Find the plugin at:
 	https://github.com/tpope/vim-commentary
 
+Additionally, this plugin sets the value of the 'comments' setting
+automatically. The 'comments' setting describes how inserting new lines should
+be handled when inside a comment region. This automatic formatting can be
+configured via the 'formatoptions' setting.
+
 ------------------------------------------------------------------------------
 INSTALLATION				*context-commentstring-installation*
 
@@ -111,6 +116,10 @@ syntax groups. When you are done with your testing, remove the echo doing: >
 	autocmd!
 	augroup END
 <
+
+The 'comments' setting can be configured the exact same way as 'commentstring'
+but the variable to change is >
+	g:context#commentstring#comments_table
 
 
 ==============================================================================

--- a/plugin/context-commentstring.vim
+++ b/plugin/context-commentstring.vim
@@ -22,6 +22,10 @@ function! s:Setup()
 			let b:original_commentstring=&l:commentstring
 			autocmd CursorMoved <buffer> call <SID>UpdateCommentString()
 		endif
+		if !empty(&filetype) && has_key(g:context#commentstring#comments_table, &filetype)
+			let b:original_comments=&l:comments
+			autocmd CursorMoved <buffer> call <SID>UpdateComments()
+		endif
 	augroup END
 endfunction
 
@@ -37,6 +41,21 @@ function! s:UpdateCommentString()
 		endfor
 	endif
 	let &l:commentstring = b:original_commentstring
+endfunction
+
+
+function! s:UpdateComments()
+	let stack = synstack(line('.'), col('.'))
+	call reverse(stack)
+	if !empty(stack)
+		for name in map(stack, 'synIDattr(v:val, "name")')
+			if has_key(g:context#commentstring#comments_table[&filetype], name)
+				let &l:comments = g:context#commentstring#comments_table[&filetype][name]
+				return
+			endif
+		endfor
+	endif
+	let &l:commentstring = b:original_comments
 endfunction
 
 


### PR DESCRIPTION
Hey! I had a problem where Vim doesn't automatically insert the comment character to the start of the line when I press `<cr>` in a comment in Vue files even if I have the `r` option in my `formatoptions`.

The problem turned out to be because Vue files have the `comments` setting set to `s:<!--,m:    ,e:-->` which is valid for HTML, but not for the sections that include other languages. The `comments` setting should be modified automatically in the exact same way that `commentstring` is currently. So, I thought that it might make sense to add this functionality to this plugin.

Just to illustrate, here's an example use case:

```vue
<script>
// This is a comment|
</script>
```

Where the cursor is in insert mode at the location noted by `|`. If I press `<cr>`, then a new line is created but the comment characters are not inserted to the start of the line:

```vue
<script>
// This is a comment
|
</script>
```

With my changes, if you have `r` in `formatoptions`, then this is the result:

```vue
<script>
// This is a comment
// |
</script>
```

I'm not sure if this plugin is the best place to add this feature to, but since it's quite similar to the existing functionality then I figured that it would make sense. Let me know what you think! Also, let me know if I should improve the documentation or anything else.