### PR TITLE
Add context commentstring for scss under vue

### DIFF
--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -39,5 +39,6 @@ let g:context#commentstring#table['typescript.tsx'] = {
 let g:context#commentstring#table['vue'] = {
 			\ 'javaScript'  : '//%s',
 			\ 'cssStyle'    : '/*%s*/',
+			\ 'vue_scss'    : '/*%s*/',
 			\}
 


### PR DESCRIPTION
For `<style></style>` tags using css, the original version will suffice. For me who sometimes use `<style lang="scss"></style>` tags with scss syntax, I simply added one line of `vue_scss` syntax group in `g:context#commentstring#table['vue']`.