### PR TITLE
Properly handle pug comments in vue files

### DIFF
--- a/autoload/context/commentstring.vim
+++ b/autoload/context/commentstring.vim
@@ -40,5 +40,6 @@ let g:context#commentstring#table['vue'] = {
 			\ 'javaScript'  : '//%s',
 			\ 'cssStyle'    : '/*%s*/',
 			\ 'vue_scss'    : '/*%s*/',
+			\ 'vue_pug'    : '// %s',
 			\}
 


### PR DESCRIPTION
This is actually a change in behavior as you might want to use `<!--` comments in pug files.

However I believe that most people would prefer to use this comment style when writing pug files.

I don't know how to collect this data or determine people's preferences here.

I would be amenable to an override system if one was convenient, but I can't seem to `let g:context#commentstring#table['vue']['vue_pug']` in any meaningful way other than adding another autoloader that clobbers these settings or is clobbered by these settings.

### An Alternative

I suggest converting all of these settings to defaults that don't clobber pre-set autoloaded variables.

I can do this conversion for all settings:
```
...
let g:context#commentstring#table['vue'] = get(g:, 'context#commentstring#table.vue', {})
let g:context#commentstring#table['vue']['javaScript'] = get(g:, 'context#commentstring#table.vue.javaScript', '//%s')
let g:context#commentstring#table['vue']['cssStyle'] = get(g:, 'context#commentstring#table.vue.cssStyle', '/*%s*/')
...
```

If we follow this path, I'll update the help page to reflect the new functionality.

It's definitely not as readable or obvious, but it does prevent clobbering. I can implement it with `if`s too if you would prefer, but that would probably be even worse.

Totally happy to discuss any alternative ways forward!